### PR TITLE
fix disqus_identifier

### DIFF
--- a/post.hbs
+++ b/post.hbs
@@ -26,7 +26,7 @@
     <div id="disqus_thread"></div>
     <script type="text/javascript">
     if(disqus_shortname && typeof disqus_shortname === "string") {
-      var disqus_identifier = '{{post.id}}';
+      var disqus_identifier = '{{id}}';
       /* * * DON'T EDIT BELOW THIS LINE * * */
       (function() {
       var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;


### PR DESCRIPTION
The original code cannot get the post's id, the disqus_identifier variable will be an empty string, so that it will use the url as the identifier. And when the permalink format being changed (e.g. set Dated Permalinks in Settings), the original comments will disappear.

This PR fix the getting of post's id. We use ```{{ id }}``` directly because of we'd already in ```<post>``` context. 
If we use disqus in a loop of posts rendering, we could use ```{{ post.id }}``` as the disqus document says.