### PR TITLE
Make theme compatible with Ghost 1.0

### DIFF
--- a/index.hbs
+++ b/index.hbs
@@ -9,7 +9,7 @@
 
 <script type="text/javascript">
 if(disqus_shortname && typeof disqus_shortname === "string") {
-  var disqus_identifier = '{{id}}';
+  var disqus_identifier = '{{comment_id}}';
   /* * * DON'T EDIT BELOW THIS LINE * * */
   (function() {
   var dsq_cnt = document.createElement('script'); dsq_cnt.type = 'text/javascript'; dsq_cnt.async = true;

--- a/post.hbs
+++ b/post.hbs
@@ -26,7 +26,7 @@
     <div id="disqus_thread"></div>
     <script type="text/javascript">
     if(disqus_shortname && typeof disqus_shortname === "string") {
-      var disqus_identifier = '{{id}}';
+      var disqus_identifier = '{{comment_id}}';
       /* * * DON'T EDIT BELOW THIS LINE * * */
       (function() {
       var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;


### PR DESCRIPTION
This pull request changes `{{id}}` to `{{comment_id}}` which makes it work Ghost 1.0